### PR TITLE
Change UDP port to make sure we capture DHCP relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,6 @@ History:
 ===========
 * DHCP Forwarder is based on go-listener (https://github.com/louismunro/go-listener) which itself is based on the UDP reflector concept.
 
+Installer:
+* 1.0: Initial release
+* 1.1: Default "Filter" UDP port changed from 68 to 67, to make sure relays are also catched. 

--- a/dhcp-forwarder-config-generator/main.go
+++ b/dhcp-forwarder-config-generator/main.go
@@ -26,7 +26,7 @@ var Config Configuration
 func main() {
 	fmt.Printf("!!! You can run this program anytime from %s !!!\n\n", os.Args[0])
 	//Set values to defaults. 0x3: DHCPREQUEST. 0x5: DHCPACK. Those are the only ones required by PacketFence to track and fingerprint devices from DHCP.
-	Config.Filter = "udp and port 68 and ((udp[250:1] = 0x3) or (udp[250:1] = 0x5))"
+	Config.Filter = "udp and port 67 and ((udp[250:1] = 0x3) or (udp[250:1] = 0x5))"
 	SelectInterface()
 	SelectRemoteHostAndPort()
 	SaveConfig("DHCP-Forwarder.toml")

--- a/dhcp-forwarder-installer/DHCP Forwarder.nsi
+++ b/dhcp-forwarder-installer/DHCP Forwarder.nsi
@@ -2,7 +2,7 @@
 
 ; HM NIS Edit Wizard helper defines
 !define PRODUCT_NAME "DHCP Forwarder"
-!define PRODUCT_VERSION "1.0"
+!define PRODUCT_VERSION "1.1"
 !define PRODUCT_PUBLISHER "Inverse Inc."
 !define PRODUCT_WEB_SITE "http://inverse.ca"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"


### PR DESCRIPTION
# Description
DHCP relays are not captured through UDP port 68 filter. Defaults have been changed in the configurator so that UDP traffic to port 67 is captured instead.

[This](https://www.cloudshark.org/captures/d636fd75a2ca) seems to prove it.

# Impacts
"C:\Program Files (x86)\DHCP Forwarder\DHCP-Forwarder.toml" needs to be manually modified and the service needs to be restarted. 

New version of the installer (1.1) reinstallation will stop, delete install new defaults recreate and start the service. Tested and working. New intaller uploaded to inverse.ca

# Issue
fixes #6 

# Delete branch after merge
YES

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Forwarder only seems to send DHCPACK (#6)